### PR TITLE
Disable symlinks for docs pages.

### DIFF
--- a/docs
+++ b/docs
@@ -1,1 +1,0 @@
-./svg-sprite


### PR DESCRIPTION
GH pages isn't a great way to do that.